### PR TITLE
Add Dockerfile to be used for building a dockerized version of the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:latest
+
+RUN apk --update add python3 && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm /var/cache/apk/* && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /usr/bin/pip3 /usr/bin/pip
+
+COPY . /tmp/
+
+RUN pip install waitress && pip install /tmp && rm -rf /tmp/*
+
+VOLUME ["/data"]
+
+EXPOSE 5000/tcp
+
+ENTRYPOINT ["/usr/bin/python", "/usr/bin/matrix_registration", "--config-path=/data/config.yaml"]
+


### PR DESCRIPTION
This adds support for building a docker image for matrix-registration. See #18 

### Building
```docker build -t "matrix-registration:latest" --rm .```

### Running
#### Registration server
```docker run -d -p 5000:5000/tcp -v $(pwd):/data matrix-registration:latest api```
#### Generating tokens
```docker run -rm -v $(pwd):/data matrix-registration:latest gen -o```
