### PR TITLE
Use a different secret for API access than the matrix shared_secret

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,6 +1,7 @@
 server_location: 'https://matrix.org'
 server_name: 'matrix.org'
 shared_secret: 'RegistrationSharedSecret'
+admin_secret: 'APIAdminPassword'
 riot_instance: 'https://riot.im/app/'
 db: 'sqlite:///{cwd}db.sqlite3'
 host: 'localhost'

--- a/matrix_registration/api.py
+++ b/matrix_registration/api.py
@@ -126,7 +126,7 @@ class RegistrationForm(Form):
 
 @auth.verify_token
 def verify_token(token):
-    return token == config.config.shared_secret
+    return token == config.config.admin_secret
 
 
 @auth.error_handler


### PR DESCRIPTION
There is no need for these 2 to be the same, and no need for the matrix
shared secret to be exposed outside the synaptic server or the
matrix-registration one.