### PR TITLE
use correct synapse admin api path

### DIFF
--- a/matrix_registration/matrix_api.py
+++ b/matrix_registration/matrix_api.py
@@ -60,13 +60,13 @@ def create_account(user, password, server_location, shared_secret,
 
     server_location = server_location.rstrip('/')
 
-    r = requests.post('%s/_matrix/client/r0/admin/register' % (server_location),
+    r = requests.post('%s/_synapse/admin/v1/register' % (server_location),
                       json=data)
     r.raise_for_status()
     return r.json()
 
 
 def _get_nonce(server_location):
-    r = requests.get('%s/_matrix/client/r0/admin/register' % (server_location))
+    r = requests.get('%s/_synapse/admin/v1/register' % (server_location))
     r.raise_for_status()
     return r.json()['nonce']


### PR DESCRIPTION
The old path is deprecated since synapse 1.20.0 and removed in 1.24.0
The new path has been available since forever it seems.