### PR TITLE
v0.9.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,2 @@
 [run]
 source = matrix_registration
-omit = matrix_registration/__main__.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:
@@ -9,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +32,7 @@ jobs:
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 matrix_registration --per-file-ignores="__init__.py:F401" --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with parameterized unit tests 🚨
         run: |
           python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 matrix:
   include:
-    - python: 3.6
     - python: 3.7
       dist: focal
       sudo: true
     - python: 3.8
+      dist: focal
+      sudo: true
+    - python: 3.9
       dist: focal
       sudo: true
 install: 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ The html page looks for the query paramater `token` and sets the token input fie
 If you already have a website and want to use your own register page, the [wiki](https://github.com/ZerataX/matrix-registration/wiki/reverse-proxy#advanced) describes a more advanced nginx setup.
 
 
+### bot
+
+if you're looking for a bot to interface with matrix-registration and manage your tokens, take a look at:
+
+[maubot-invite](https://github.com/williamkray/maubot-invite)
+
+
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -107,17 +107,6 @@ if you're looking for a bot to interface with matrix-registration and manage you
 [maubot-invite](https://github.com/williamkray/maubot-invite)
 
 
-
-### Troubleshooting
-
-#### SQLAlchemy complains that a value isn't in a DateTime value
-
-Before #17 introduced SQLAlchemy support the sqlite database incorrectly stored the expire dates, to fix this you have to manually run:
-```sql
-update tokens set ex_date=null where ex_date='None';
-```
-on your database once, or just delete your current database.
-
 ### Similar projects
 
   - [matrix-invite](https://gitlab.com/reivilibre/matrix-invite) live at https://librepush.net/matrix/registration/

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,71 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,90 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+import sys
+from os import getcwd
+from os.path import abspath, dirname
+
+sys.path.insert(0, dirname(dirname(abspath(__file__))))
+
+from matrix_registration import config as mr_config
+
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# load matrix-registration config and set db path for alembic
+config_path = context.get_x_argument(as_dictionary=True).get("config") or "config.yaml"
+mr_config.config = mr_config.Config(config_path)
+config.set_main_option("sqlalchemy.url", mr_config.config.db.replace("{cwd}", f"{getcwd()}/"))
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/140a25d5f185_create_tokens_table.py
+++ b/alembic/versions/140a25d5f185_create_tokens_table.py
@@ -1,0 +1,69 @@
+"""create tokens table
+
+Revision ID: 140a25d5f185
+Revises: 
+Create Date: 2020-12-12 01:44:28.195736
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Table, Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy.engine.reflection import Inspector
+from flask_sqlalchemy import SQLAlchemy
+
+
+# revision identifiers, used by Alembic.
+revision = '140a25d5f185'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+db = SQLAlchemy()
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    tables = inspector.get_table_names()
+
+    if 'ips' not in tables:
+        op.create_table(
+            'ips',
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('address', sa.String(255), nullable=True)
+        )
+
+    if 'tokens' not in tables:
+        op.create_table(
+            'tokens',
+            sa.Column('name', String(255), primary_key=True),
+            sa.Column('expiration_date', DateTime, nullable=True),
+            sa.Column('max_usage', Integer, default=1),
+            sa.Column('used', Integer, default=0),
+            sa.Column('disabled', Boolean, default=False),
+            sa.Column('ips', Integer, ForeignKey('association.id'))
+        )
+    else:
+        with op.batch_alter_table('tokens') as batch_op:
+            batch_op.alter_column('ex_date', new_column_name='expiration_date', nullable=True)
+            batch_op.alter_column('one_time', new_column_name='max_usage')
+
+            batch_op.add_column(
+                Column('disabled', Boolean, default=False)
+            )
+
+
+    if 'association' not in tables:
+        op.create_table(
+        'association', db.Model.metadata,
+            Column('ips', String, ForeignKey('ips.address'), primary_key=True),
+            Column('tokens', Integer, ForeignKey('tokens.name'), primary_key=True)
+        )   
+    
+    op.execute("update tokens set expiration_date=null where expiration_date='None'")
+
+
+
+def downgrade():
+    op.alter_column('tokens', 'expiration_date', new_column_name='ex_date')
+    op.alter_column('tokens', 'max_usage', new_column_name='one_time')

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,16 +1,18 @@
 server_location: 'https://matrix.org'
 server_name: 'matrix.org'
-shared_secret: 'RegistrationSharedSecret'
-admin_secret: 'APIAdminPassword'
-base_url: ''
-riot_instance: 'https://riot.im/app/'
+registration_shared_secret: 'RegistrationSharedSecret' # see your synapse's homeserver.yaml
+admin_api_shared_secret: 'APIAdminPassword' # to generate tokens via the web api
+base_url: '' # e.g. '/element' for https://example.tld/element/register
+client_redirect: 'https://app.element.io/#/login'
+client_logo: 'static/images/element-logo.png' # use '{cwd}' for current working directory
 db: 'sqlite:///{cwd}db.sqlite3'
 host: 'localhost'
 port: 5000
 rate_limit: ["100 per day", "10 per minute"]
 allow_cors: false
+ip_logging: false
 logging:
-  disable_existing_loggers: False
+  disable_existing_loggers: false
   version: 1
   root:
     level: DEBUG

--- a/matrix_registration/__init__.py
+++ b/matrix_registration/__init__.py
@@ -2,5 +2,5 @@ from . import api
 from . import tokens
 from . import config
 
-__version__ = '0.9.0.dev0'
+__version__ = '0.9.0.dev1'
 name = 'matrix_registration'

--- a/matrix_registration/__init__.py
+++ b/matrix_registration/__init__.py
@@ -2,5 +2,5 @@ from . import api
 from . import tokens
 from . import config
 
-__version__ = '0.8.1.dev3'
+__version__ = '0.9.0.dev0'
 name = 'matrix_registration'

--- a/matrix_registration/app.py
+++ b/matrix_registration/app.py
@@ -59,10 +59,11 @@ def run_server(info):
 
 
 @cli.command("generate", help="generate new token")
-@click.option("-o", "--one-time", is_flag=True, help="make token one-time-useable")
-@click.option("-e", "--expires", type=click.DateTime(formats=["%Y-%m-%d"]), default=None, help='expire date: in ISO-8601 format (YYYY-MM-DD)')
-def generate_token(one_time, expires):
-    token = tokens.tokens.new(ex_date=expires, one_time=one_time)
+@click.option("-m", "--maximum", default=0, help="times token can be used")
+@click.option("-e", "--expires", type=click.DateTime(formats=["%Y-%m-%d"]),
+              default=None, help='expire date: in ISO-8601 format (YYYY-MM-DD)')
+def generate_token(maximum, expires):
+    token = tokens.tokens.new(expiration_date=expires, max_usage=maximum)
     print(token.name)
 
 
@@ -76,12 +77,12 @@ def status_token(status, list, disable):
             print("Token disabled")
         else:
             print("Token couldn't be disabled")
-    if status:
+    elif status:
         token = tokens.tokens.get_token(status)
         if token:
-            print(f"This token is{' ' if token.valid else ' not '}valid")
+            print(f"This token is{' ' if token.active() else ' not '}valid")
             print(json.dumps(token.toDict(), indent=2))
         else:
             print("No token with that name")
-    if list:
+    elif list:
         print(tokens.tokens)

--- a/matrix_registration/templates/register.html
+++ b/matrix_registration/templates/register.html
@@ -16,7 +16,7 @@
   <meta name="msapplication-TileImage" content="{{ url_for('static', filename='images/tile.png') }}">
   <meta name="msapplication-TileColor" content="#fff">
   <title>{{ translations.server_registration }}</title>
-  <!-- font designed by Designed by Vernon Adams, Cyreal -->
+  <!-- font designed by Vernon Adams, Cyreal -->
   <!-- https://fonts.google.com/specimen/Nunito -->
   <!-- licensed under SIL Open Font License, Version 1.1 -->
   <link rel="preload" as="font" href="{{ url_for('static', filename='fonts/Nunito_400_Nunito_700.woff2') }}" type="font/woff2" crossorigin="anonymous">
@@ -88,7 +88,7 @@
       </header>
       <section>
         <p> {{ translations.click_to_login }}</p>
-        <h3><a href="{{ riot_instance }}"><img src="{{ url_for('static', filename='images/icon32x32.png') }}" height="100px"></a></h3>
+        <h3><a href="{{ client_redirect }}"><img src="{{ base_url }}/static/replace/images/element-logo.png" height="100px"></a></h3>
         <p>{{ translations.choose_client }} <a href="https://matrix.org/docs/projects/clients-matrix"
             a>https://matrix.org/docs/projects/clients-matrix</a></p>
       </section>
@@ -217,7 +217,7 @@
           console.log(response)
         } catch (e) {
           if (e instanceof SyntaxError) {
-            showError("{{ translations.internal_error }}")
+            showError("{{ translations.internal_error }}", "{{ translations.contact }}")
             return
           }
         }
@@ -243,7 +243,7 @@
 
       // Define what happens in case of error
       XHR.addEventListener("error", function (event) {
-        showError("{{ translations.internal_error }}")
+        showError("{{ translations.internal_error }}", "{{ translations.contact }}")
       })
 
       // Set up our request

--- a/matrix_registration/translation.py
+++ b/matrix_registration/translation.py
@@ -25,7 +25,7 @@ def _get_translations(lang='en', replacements={}):
         translations = yaml.load(stream, Loader=yaml.SafeLoader)
 
     interpolated_translations = {}
-    for key, value  in translations['weblate'].items():
+    for key, value in translations['weblate'].items():
         match = re.search(replace_pattern, value)
         while match:
             value = value.replace(match.group(0), str(replacements[match.group('name')]))

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import codecs
 import os
 import re
 import setuptools
+import glob
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -45,15 +46,15 @@ setuptools.setup(
                                           'static/images/*.jpg',
                                           'static/images/*.png',
                                           'static/images/*.ico']},
-    python_requires='~=3.6',
+    python_requires='~=3.7',
     install_requires=[
+        "alembic>=1.3.2",
         "appdirs~=1.4.3",
         "Flask~=1.1",
         "Flask-SQLAlchemy~=2.4.1",
         "flask-cors~=3.0.7",
         "flask-httpauth>=3.3.0",
         "flask-limiter>=1.1.0",
-        "python-dateutil~=2.8.1",
         "PyYAML~=5.1",
         "requests>=2.22",
         "SQLAlchemy>=1.3.13,<1.4",
@@ -69,17 +70,19 @@ setuptools.setup(
         "Development Status :: 4 - Beta",
         "Topic :: Communications :: Chat",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8"
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9"
     ],
     entry_points={
         'console_scripts': [
             'matrix-registration=matrix_registration.app:cli'
         ],
     },
-    test_suite="tests.test_registration",
     data_files=[
         ("config", ["config.sample.yaml"]),
+        (".", ["alembic.ini"]),
+        ("alembic", ["alembic/env.py"]),
+        ("alembic/versions", glob.glob("alembic/versions/*.py"))
     ]
 )

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ in buildPythonPackage {
   src = ./.;
   propagatedBuildInputs = [
     pkgs.libsndfile
+    alembic
     appdirs
     flask
     flask-cors

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -65,7 +65,7 @@ LOGGING = {
 GOOD_CONFIG = {
     'server_location': 'https://righths.org',
     'registration_shared_secret': 'coolsharesecret',
-    'admin_secret': 'coolpassword',
+    'admin_api_shared_secret': 'coolpassword',
     'base_url': '/element',
     'db': 'sqlite:///%s/tests/db.sqlite' % (os.getcwd(),),
     'port': 5000,
@@ -83,7 +83,7 @@ BAD_CONFIG1 = dict(  # wrong matrix server location -> 500
 
 BAD_CONFIG2 = dict(  # wrong admin secret password -> 401
     GOOD_CONFIG.items(),
-    admin_secret='wrongpassword',
+    admin_api_shared_secret='wrongpassword',
 )
 
 BAD_CONFIG3 = dict(  # wrong matrix shared password -> 500
@@ -479,7 +479,7 @@ class ApiTest(unittest.TestCase):
             test_token = matrix_registration.tokens.tokens.new(expiration_date=None,
                                                                max_usage=True)
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             headers = {'Authorization': 'SharedSecret %s' % secret}
             rv = self.client.get('/api/token', headers=headers)
 
@@ -497,7 +497,7 @@ class ApiTest(unittest.TestCase):
             test_token = matrix_registration.tokens.tokens.new(expiration_date=None,
                                                                max_usage=True)
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             matrix_registration.config.config = Config(GOOD_CONFIG)
             headers = {'Authorization': 'SharedSecret %s' % secret}
             rv = self.client.get('/api/token', headers=headers)
@@ -521,7 +521,7 @@ class ApiTest(unittest.TestCase):
             test_token = matrix_registration.tokens.tokens.new(expiration_date=None,
                                                                max_usage=True)
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             headers = {'Authorization': 'SharedSecret %s' % secret}
             rv = self.client.post('/api/token',
                                   data=json.dumps(dict(expiration_date=expiration_date,
@@ -543,7 +543,7 @@ class ApiTest(unittest.TestCase):
             test_token = matrix_registration.tokens.tokens.new(expiration_date=None,
                                                                max_usage=True)
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             matrix_registration.config.config = Config(GOOD_CONFIG)
             headers = {'Authorization': 'SharedSecret %s' % secret}
             rv = self.client.post('/api/token',
@@ -558,7 +558,7 @@ class ApiTest(unittest.TestCase):
             self.assertEqual(token_data['errcode'], 'MR_BAD_SECRET')
             self.assertEqual(token_data['error'], 'wrong shared secret')
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             headers = {'Authorization': 'SharedSecret %s' % secret}
             rv = self.client.post('/api/token',
                                   data=json.dumps(dict(expiration_date='2020-24-12',
@@ -578,7 +578,7 @@ class ApiTest(unittest.TestCase):
             matrix_registration.tokens.tokens = matrix_registration.tokens.Tokens()
             test_token = matrix_registration.tokens.tokens.new(max_usage=True)
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             headers = {'Authorization': 'SharedSecret %s' % secret}
             rv = self.client.patch('/api/token/' + test_token.name,
                                  data=json.dumps(dict(disabled=True)),
@@ -598,7 +598,7 @@ class ApiTest(unittest.TestCase):
             matrix_registration.tokens.tokens = matrix_registration.tokens.Tokens()
             test_token = matrix_registration.tokens.tokens.new(max_usage=True)
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             headers = {'Authorization': 'SharedSecret %s' % secret}
             matrix_registration.config.config = Config(GOOD_CONFIG)
             rv = self.client.patch('/api/token/' + test_token.name,
@@ -611,7 +611,7 @@ class ApiTest(unittest.TestCase):
             self.assertEqual(token_data['errcode'], 'MR_BAD_SECRET')
             self.assertEqual(token_data['error'], 'wrong shared secret')
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             headers = {'Authorization': 'SharedSecret %s' % secret}
             rv = self.client.patch('/api/token/' + test_token.name,
                                  data=json.dumps(dict(active=False)),
@@ -646,7 +646,7 @@ class ApiTest(unittest.TestCase):
             test_token = matrix_registration.tokens.tokens.new(expiration_date=expiration_date,
                                                                max_usage=max_usage)
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             headers = {'Authorization': 'SharedSecret %s' % secret}
             rv = self.client.get('/api/token/' + test_token.name,
                                  content_type='application/json',
@@ -663,7 +663,7 @@ class ApiTest(unittest.TestCase):
             matrix_registration.tokens.tokens = matrix_registration.tokens.Tokens()
             test_token = matrix_registration.tokens.tokens.new(max_usage=True)
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             headers = {'Authorization': 'SharedSecret %s' % secret}
             rv = self.client.get('/api/token/' + 'nice_meme',
                                  content_type='application/json',
@@ -676,7 +676,7 @@ class ApiTest(unittest.TestCase):
 
             matrix_registration.config.config = Config(BAD_CONFIG2)
 
-            secret = matrix_registration.config.config.admin_secret
+            secret = matrix_registration.config.config.admin_api_shared_secret
             headers = {'Authorization': 'SharedSecret %s' % secret}
             matrix_registration.config.config = Config(GOOD_CONFIG)
             rv = self.client.patch('/api/token/' + test_token.name,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py37,py38,p39
 [testenv]
 deps = coveralls
 commands = coverage erase


### PR DESCRIPTION
this is #25 without the changes done for nixos packaging.
still a big PR, but everything else I already tested and now only really need feedback on before merging

  - this should close #58
by renaming `shared_secret` to `registration_shared_secret` and
`admin_secret` to `admin_api_shared_secret`

I also added a tiny explanation in the config file
https://github.com/ZerataX/matrix-registration/blob/286d5336e8a9c58431089b510b57214e45e07707/config.sample.yaml#L3-L4

  - this closes #55
 by changing the option for one time use to giving a positive number for amount the token can be used
```
 -m, --maximum INTEGER     times token can be used
```

  - this closes #38
by giving an option in the config file to log IPs to the database
https://github.com/ZerataX/matrix-registration/blob/286d5336e8a9c58431089b510b57214e45e07707/config.sample.yaml#L13

when checking the status of individual token via the cli or web api the IPs are viewable

  - finally this closes #16

by changing the web api:
- every endpoint is now under the `/api/` subdirectory
- added a version endpoint `/api/version` that respons with e.g. `{"version":"0.9.0.dev0"}`
- PUT -> PATCH for `/api/token`
- renaming the following properties
  - `valid` -> `active`
  - `one_time` -> `max_usage` 
  - `ex_date` -> `expiration_date` 

Additionally, but very important you can now upgrade the database to the new scheme with

```
alembic upgrade head
```

all of these changes are breaking, I'm not really interested in backwards compatibility until version 1.0.0, which will come when #25 is done

I'll push out a tagged release for v0.9.0.dev0 with a docker image in probably a few hours

sorry for the delay