### PR TITLE
Update Flask-Limiter usage

### DIFF
--- a/matrix_registration/app.py
+++ b/matrix_registration/app.py
@@ -6,7 +6,7 @@ import json
 from flask import Flask
 from flask.cli import FlaskGroup, pass_script_info
 from flask_limiter import Limiter
-from flask_limiter.util import get_ipaddr
+from flask_limiter.util import get_ip_from_header
 from flask_cors import CORS
 from waitress import serve
 
@@ -57,7 +57,7 @@ def cli(info, config_path):
 @pass_script_info
 def run_server(info):
     app = info.load_app()
-    Limiter(app, key_func=get_ipaddr, default_limits=config.config.rate_limit)
+    Limiter(app, key_func=get_ip_from_header, default_limits=config.config.rate_limit)
     if config.config.allow_cors:
         CORS(app)
     serve(

--- a/matrix_registration/app.py
+++ b/matrix_registration/app.py
@@ -6,7 +6,7 @@ import json
 from flask import Flask
 from flask.cli import FlaskGroup, pass_script_info
 from flask_limiter import Limiter
-from flask_limiter.util import get_ip_from_header
+from flask_limiter.util import get_remote_address
 from flask_cors import CORS
 from waitress import serve
 
@@ -57,7 +57,7 @@ def cli(info, config_path):
 @pass_script_info
 def run_server(info):
     app = info.load_app()
-    Limiter(app, key_func=get_ip_from_header, default_limits=config.config.rate_limit)
+    Limiter(app, key_func=get_remote_address, default_limits=config.config.rate_limit)
     if config.config.allow_cors:
         CORS(app)
     serve(


### PR DESCRIPTION
v2.0.1 removes the deprecated `get_ipaddr` method. <strike>`get_ip_from_header`</strike> `get_remote_address` has to be used instead or the service fails to start with the following error message:
```
Traceback (most recent call last):
  File "/usr/local/bin/matrix-registration", line 5, in <module>
    from matrix_registration.app import cli
  File "/usr/local/lib/python3.8/site-packages/matrix_registration/app.py", line 9, in <module>
    from flask_limiter.util import get_ipaddr
ImportError: cannot import name 'get_ipaddr' from 'flask_limiter.util' (/usr/local/lib/python3.8/site-packages/flask_limiter/util.py)
```