### PR TITLE
fix: Support IP logging behind a reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you'd like to run matrix-registration behind a reverse-proxy, here is an exam
 
 ```nginx
 location  ~ ^/(static|register) {
-        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass http://localhost:5000;
 }
 ```


### PR DESCRIPTION
Previously, this would always log the proxy's internal address, if behind a reverse proxy, or the real remote address if not. By combining the apparent remote_addr with the XFF chain, we can get the best possible information without having to know whether we're behind a proxy. (This assumes the proxy is set up to append to the XFF chain, so the example in the README is updated and corrected.)

This is to address https://github.com/ZerataX/matrix-registration/issues/82