### PR TITLE
fix: Don't depend on `home_server` field in registration response

### DIFF
--- a/matrix_registration/api.py
+++ b/matrix_registration/api.py
@@ -260,7 +260,6 @@ def create_account_from_form(form):
     logger.debug("account creation succeded!")
     return jsonify(
         access_token=account_data["access_token"],
-        home_server=account_data["home_server"],
         user_id=account_data["user_id"],
         status="success",
         status_code=200,


### PR DESCRIPTION
This field is deprecated in the client-server API and has been removed from Dendrite, causing the UI to error when handling a registration response.

Reference: https://spec.matrix.org/v1.6/client-server-api/#post_matrixclientv3register

It appears that the `home_server` field wasn't actually being used here anyhow, so just remove the line that tries to fetch it. The spec indicates that if it is needed, the caller should instead split the user_id at the first colon.

Fixes https://github.com/zeratax/matrix-registration/issues/103