### PR TITLE
Provide link after token generated

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,5 +1,8 @@
 server_location: 'http://localhost:8008'
 server_name: 'matrix.org'
+registration_url: "https://your.registeration.page" # Used to prompt for a link when generating tokens through the cli
+default_token_maximum: 0 # default maximum usage for tokens, 0 means unlimited
+default_token_expiration: never # default expiration period for tokens. availble values are "never", "day", "week", "month" or a string in ISO-8601 format (YYYY-MM-DD).
 registration_shared_secret: 'RegistrationSharedSecret' # see your synapse's homeserver.yaml
 admin_api_shared_secret: 'APIAdminPassword' # to generate tokens via the web api
 base_url: '' # e.g. '/element' for https://example.tld/element/register

--- a/matrix_registration/app.py
+++ b/matrix_registration/app.py
@@ -71,18 +71,21 @@ def run_server(info):
 @click.option(
     "-e",
     "--expires",
-    type=tokens.ExpireTime,
-    default="",
+    default=None,
     help="expire date: one of 'never', 'day', 'week', 'month' or ISO-8601 date (YYYY-MM-DD)"
 )
 def generate_token(maximum, expires):
     if maximum is None:
         maximum = config.config.default_token_maximum
-    if expires == "":
+    if expires is None:
         expires = config.config.default_token_expiration
-        expires = tokens.ExpireTime.convert(expires, None, None)
+    expireTime = tokens.Token.convert(expires)
 
-    token = tokens.tokens.new(expiration_date=expires, max_usage=maximum)
+    if expireTime is None and expires != "never":
+        print(f"expires '{expires}' is not valid. Expected 'never', 'day', 'week', 'month' or ISO-8601 date (YYYY-MM-DD)")
+        return -1
+
+    token = tokens.tokens.new(expiration_date=expireTime, max_usage=maximum)
     # print(token.name)
 
     print(f"Token generated: {token.name}")
@@ -90,7 +93,7 @@ def generate_token(maximum, expires):
         print(f"With maximum usage: {token.max_usage}")
     else:
         print("With no maximum usage")
-    if expires:
+    if token.expiration_date is not None:
         print(f"expires at: {token.expiration_date}")
     else:
         print("Never expires")

--- a/matrix_registration/app.py
+++ b/matrix_registration/app.py
@@ -71,16 +71,16 @@ def run_server(info):
 @click.option(
     "-e",
     "--expires",
-    type=tokens.ExpireType,
+    type=tokens.ExpireTime,
     default="",
     help="expire date: one of 'never', 'day', 'week', 'month' or ISO-8601 date (YYYY-MM-DD)"
 )
 def generate_token(maximum, expires):
     if maximum is None:
         maximum = config.config.default_token_maximum
-    if expires is "":
+    if expires == "":
         expires = config.config.default_token_expiration
-        expires = tokens.ExpireType.convert(expires, None, None)
+        expires = tokens.ExpireTime.convert(expires, None, None)
 
     token = tokens.tokens.new(expiration_date=expires, max_usage=maximum)
     # print(token.name)

--- a/matrix_registration/app.py
+++ b/matrix_registration/app.py
@@ -67,17 +67,24 @@ def run_server(info):
 
 
 @cli.command("generate", help="generate new token")
-@click.option("-m", "--maximum", default=0, help="times token can be used")
+@click.option("-m", "--maximum", default=None, help="times token can be used")
 @click.option(
     "-e",
     "--expires",
-    type=click.DateTime(formats=["%Y-%m-%d"]),
-    default=None,
-    help="expire date: in ISO-8601 format (YYYY-MM-DD)",
+    type=tokens.ExpireType,
+    default="",
+    help="expire date: one of 'never', 'day', 'week', 'month' or ISO-8601 date (YYYY-MM-DD)"
 )
 def generate_token(maximum, expires):
+    if maximum is None:
+        maximum = config.config.default_token_maximum
+    if expires is "":
+        expires = config.config.default_token_expiration
+        expires = tokens.ExpireType.convert(expires, None, None)
+
     token = tokens.tokens.new(expiration_date=expires, max_usage=maximum)
     # print(token.name)
+
     print(f"Token generated: {token.name}")
     if token.max_usage != 0:
         print(f"With maximum usage: {token.max_usage}")
@@ -87,6 +94,7 @@ def generate_token(maximum, expires):
         print(f"expires at: {token.expiration_date}")
     else:
         print("Never expires")
+    print(f"URL: {config.config.registration_url}/register?token={token.name}")
 
 
 @cli.command("status", help="view status or disable")

--- a/matrix_registration/app.py
+++ b/matrix_registration/app.py
@@ -77,7 +77,16 @@ def run_server(info):
 )
 def generate_token(maximum, expires):
     token = tokens.tokens.new(expiration_date=expires, max_usage=maximum)
-    print(token.name)
+    # print(token.name)
+    print(f"Token generated: {token.name}")
+    if token.max_usage != 0:
+        print(f"With maximum usage: {token.max_usage}")
+    else:
+        print("With no maximum usage")
+    if expires:
+        print(f"expires at: {token.expiration_date}")
+    else:
+        print("Never expires")
 
 
 @cli.command("status", help="view status or disable")

--- a/matrix_registration/config.schema.json
+++ b/matrix_registration/config.schema.json
@@ -9,6 +9,15 @@
     "server_name": {
       "type": "string"
     },
+    "registration_url": {
+      "type": "string"
+    },
+    "default_token_maximum": {
+      "type": "integer"
+    },
+    "default_token_expiration": {
+      "type": ["string", "null"]
+    },
     "registration_shared_secret": {
       "type": "string"
     },

--- a/matrix_registration/tokens.py
+++ b/matrix_registration/tokens.py
@@ -2,7 +2,6 @@
 from datetime import datetime, timedelta
 import logging
 import random
-import click
 
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import (
@@ -115,11 +114,7 @@ class Token(db.Model):
             return True
         return False
 
-class ExpireTime(click.ParamType):
-    name = "expire"
-
-    def convert(self, value, param, ctx):
-
+    def convert(value):
         v = value.lower()
         if v == "never":
             return None
@@ -133,9 +128,8 @@ class ExpireTime(click.ParamType):
         try:
             return datetime.strptime(value, "%Y-%m-%d")
         except ValueError:
-            self.fail(f"{value} is not valid. Expected 'never', 'day', 'week', 'month' or ISO date (YYYY-MM-DD)", param, ctx)
+            return None
 
-ExpireTime = ExpireTime()
 
 class Tokens:
     def __init__(self):

--- a/matrix_registration/tokens.py
+++ b/matrix_registration/tokens.py
@@ -126,11 +126,11 @@ class ExpireType(click.ParamType):
         if v == "never":
             return None
         elif v == "day":
-            return datetime.datetime.combine(today + datetime.timedelta(days=1), datetime.time.min)
+            return datetime.datetime.now() + datetime.timedelta(days=1)
         elif v == "week":
-            return datetime.datetime.combine(today + datetime.timedelta(weeks=1), datetime.time.min)
+            return datetime.datetime.now() + datetime.timedelta(weeks=1)
         elif v == "month":
-            return datetime.datetime.combine(today + datetime.timedelta(days=30), datetime.time.min)
+            return datetime.datetime.now() + datetime.timedelta(days=30)
 
         try:
             return datetime.datetime.strptime(value, "%Y-%m-%d")

--- a/matrix_registration/tokens.py
+++ b/matrix_registration/tokens.py
@@ -1,7 +1,9 @@
 # Standard library imports...
-from datetime import datetime
+# from datetime import datetime
+import datetime
 import logging
 import random
+import click
 
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import (
@@ -114,6 +116,32 @@ class Token(db.Model):
             return True
         return False
 
+class ExpireType(click.ParamType):
+    name = "expire"
+
+    def convert(self, value, param, ctx):
+        today = datetime.date.today()
+
+        v = value.lower()
+        if v == "never":
+            return None
+        elif v == "day":
+            return datetime.datetime.combine(today + datetime.timedelta(days=1), datetime.time.min)
+        elif v == "week":
+            return datetime.datetime.combine(today + datetime.timedelta(weeks=1), datetime.time.min)
+        elif v == "month":
+            return datetime.datetime.combine(today + datetime.timedelta(days=30), datetime.time.min)
+
+        try:
+            return datetime.datetime.strptime(value, "%Y-%m-%d")
+        except ValueError:
+            self.fail(
+                f"{value} is not valid. Expected 'never', 'day', 'week', 'month' or ISO date (YYYY-MM-DD)",
+                param,
+                ctx
+            )
+
+ExpireType = ExpireType()
 
 class Tokens:
     def __init__(self):

--- a/matrix_registration/tokens.py
+++ b/matrix_registration/tokens.py
@@ -1,6 +1,5 @@
 # Standard library imports...
-# from datetime import datetime
-import datetime
+from datetime import datetime, timedelta
 import logging
 import random
 import click
@@ -116,32 +115,27 @@ class Token(db.Model):
             return True
         return False
 
-class ExpireType(click.ParamType):
+class ExpireTime(click.ParamType):
     name = "expire"
 
     def convert(self, value, param, ctx):
-        today = datetime.date.today()
 
         v = value.lower()
         if v == "never":
             return None
         elif v == "day":
-            return datetime.datetime.now() + datetime.timedelta(days=1)
+            return datetime.now() + timedelta(days=1)
         elif v == "week":
-            return datetime.datetime.now() + datetime.timedelta(weeks=1)
+            return datetime.now() + timedelta(weeks=1)
         elif v == "month":
-            return datetime.datetime.now() + datetime.timedelta(days=30)
+            return datetime.now() + timedelta(days=30)
 
         try:
-            return datetime.datetime.strptime(value, "%Y-%m-%d")
+            return datetime.strptime(value, "%Y-%m-%d")
         except ValueError:
-            self.fail(
-                f"{value} is not valid. Expected 'never', 'day', 'week', 'month' or ISO date (YYYY-MM-DD)",
-                param,
-                ctx
-            )
+            self.fail(f"{value} is not valid. Expected 'never', 'day', 'week', 'month' or ISO date (YYYY-MM-DD)", param, ctx)
 
-ExpireType = ExpireType()
+ExpireTime = ExpireTime()
 
 class Tokens:
     def __init__(self):


### PR DESCRIPTION
It would be better if `matrix-registration generate` could provide a link to the register page with token filled. (My code is a bit rough and may wouldn't adapt to those who uses custom register page)

To achive this, `registration_url` was added to `config.yaml`. Also added `default_token_maximum` & `default_token_expiration`, plus some keyword expiration duration("never", "day", "week", "month")

This PR involves modifications to `config.schema.json`, using config without fields above casue errors.

btw the CLI tests failed, but running the tests with the latest code from the repository also seems to fail, so it should not be an issue on my side. It works on my matrix tough. I am not entirely sure if my implementation is reasonable. If there is a better way to a implementation this, feel free to edit or close it.