### PR TITLE
Fix: zh-CN not showing zh_Hans translate

### DIFF
--- a/matrix_registration/api.py
+++ b/matrix_registration/api.py
@@ -206,6 +206,8 @@ def register():
     uname_regex_inv = config.config.username["invalidation_regex"]
     lang = request.args.get("lang") or request.accept_languages.best
     replacements = {"server_name": server_name, "pw_length": pw_length}
+    if lang == "zh-CN":
+        lang = "zh_Hans"
     translations = get_translations(lang, replacements)
     return render_template(
         "register.html",

--- a/matrix_registration/templates/register.html
+++ b/matrix_registration/templates/register.html
@@ -146,8 +146,15 @@
 
     // set "?lang=" parameter to user lang
     const userLang = navigator.language || navigator.userLanguage
+    let mappedUserLang = userLang
+
+    // map zh-CN to zh-Hans
+    if (userLang == "zh-CN") {
+      mappedUserLang = "zh_Hans"
+    }
+
     if (!urlParams.has("lang")) { 
-      urlParams.append("lang", userLang)
+      urlParams.append("lang", mappedUserLang)
       window.history.replaceState({}, '', `${location.pathname}?${urlParams}`);
     }
 


### PR DESCRIPTION
In Simplified Chinese environments, most of the time the browser will  recognize the language as `zh-CN` rather than `zh_Hans`. Some simple scripting would help, but it would be better to establish a mapping for other languages with similar issues.
